### PR TITLE
correcting path to create elk containers

### DIFF
--- a/elk_metrics/readme.rst
+++ b/elk_metrics/readme.rst
@@ -41,7 +41,7 @@ Create the containers
 
 .. code-block:: bash
 
-   cd /opt/openstack-ansible-playbooks
+   cd /opt/openstack-ansible/playbooks
    openstack-ansible lxc-containers-create.yml -e 'container_group=elastic-logstash:kibana'
 
 install master/data elasticsearch nodes on the elastic-logstash containers


### PR DESCRIPTION
Replacing "-" to "/" in the line containing the path to create the lxc containers