### PR TITLE
Add log_hosts to install documentation

### DIFF
--- a/elk_metrics_6x/README.rst
+++ b/elk_metrics_6x/README.rst
@@ -268,7 +268,7 @@ Create the containers
 .. code-block:: bash
 
    cd /opt/openstack-ansible/playbooks
-   openstack-ansible lxc-containers-create.yml --limit elk_all
+   openstack-ansible lxc-containers-create.yml --limit elk_all,log_hosts
 
 
 Deploying | Installing with embedded Ansible


### PR DESCRIPTION
If you limit to only elk_all the container creation will fail. We need to specify the logging node as well to be able to create the containers.